### PR TITLE
feat:#17カテゴリー機能の実装（カテゴリー別画面はまだ）

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Requests\PostRequest;
 use App\Models\Post;
+use App\Models\Category;
 
 class PostController extends Controller
 {
@@ -16,8 +17,8 @@ class PostController extends Controller
         return view('posts.show')->with(['post'=>$post]);
     }
     
-    public function create(){
-        return view('posts.create');
+    public function create(Category $category){
+        return view('posts.create')->with(['categories'=>$category->get()]);
     }
     
     public function store(PostRequest $request,Post $post){

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Category extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+    
+    public function posts(){
+        return $this->hasMany(Post::class);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -15,8 +15,13 @@ class Post extends Model
         return $this->orderBy('updated_at','desc')->paginate($limit);
     }
     
+    public function category(){
+        return $this->belongsTo(Category::class);
+    }
+    
     protected $fillable=[
         'title',
         'body',
+        'category_id',
         ];
 }

--- a/database/migrations/2023_12_09_095316_create_categories_table.php
+++ b/database/migrations/2023_12_09_095316_create_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name',50);
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2023_12_09_101645_add_category_id_to_posts_table.php
+++ b/database/migrations/2023_12_09_101645_add_category_id_to_posts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            //onDelete('cascade')で反映されるのは物理削除のみ。論理削除の場合は投稿は削除されない。
+            $table->foreignId('category_id')->constrained()->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            //
+            $table->dropColumn('category_id');
+        });
+    }
+};

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //DBからテーブルを呼び出してinsertする
+        //https://readouble.com/laravel/9.x/ja/seeding.html?header=%25E3%2582%25B7%25E3%2583%25BC%25E3%2583%2580%25E3%2582%25AF%25E3%2583%25A9%25E3%2582%25B9%25E5%25AE%259A%25E7%25BE%25A9
+        DB::table('categories')->insert([
+            'name' => '動物'     
+        ]);
+        DB::table('categories')->insert([
+            'name' => '乗り物'     
+        ]);
+        DB::table('categories')->insert([
+            'name' => '自然'     
+        ]);
+        DB::table('categories')->insert([
+            'name' => '建物'     
+        ]);
+        DB::table('categories')->insert([
+            'name' => '街中'     
+        ]);
+        
+        
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,5 +21,6 @@ class DatabaseSeeder extends Seeder
         //     'email' => 'test@example.com',
         // ]);
         $this->call(PostSeeder::class);
+        $this->call(CategorySeedr::class);
     }
 }

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -16,25 +16,30 @@ class PostSeeder extends Seeder
     public function run()
     {
         DB::table('posts')->insert([
-            'title'=>'test01',
-            'body'=>'これはテストです',
+            'title'=>'ポケモン',
+            'body'=>'ダウンロードコンテンツがもうすぐ発売です！',
+            'category_id'=>1
             ]);
         
         DB::table('posts')->insert([
-            'title'=>'test02',
-            'body'=>'これはテストです',
+            'title'=>'イチョウ',
+            'body'=>'この前イチョウ並木を見てきました。圧巻！！',
+            'category_id'=>2
             ]);
         DB::table('posts')->insert([
-            'title'=>'test03',
-            'body'=>'これはテストです',
+            'title'=>'ひまわり',
+            'body'=>'夏のひまわり畑が素敵でした',
+            'category_id'=>3
             ]);
         DB::table('posts')->insert([
-            'title'=>'test04',
-            'body'=>'これはテストです',
+            'title'=>'さくら',
+            'body'=>'千葉公園の桜がとてもきれいでした',
+            'category_id'=>2
             ]);
         DB::table('posts')->insert([
-            'title'=>'test05',
-            'body'=>'これはテストです',
+            'title'=>'イルミネーション',
+            'body'=>'六本木に初上陸。イルミネーションにみんな見とれていました。',
+            'category_id'=>3
             ]);
         
     }

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -35,6 +35,14 @@
             <!--
             バリデーションのエラーメッセージのattributeはリクエストクラス（PostRequest）で指定できる
             -->
+            <h2>カテゴリー</h2>
+            <select name="post[category_id]">
+                @foreach($categories as $category)
+                    <option value="{{$category->id}}">{{$category->name}}</option>
+                @endforeach
+            </select>
+            </br>
+            </br>
             </br>
             <input type="submit" value="保存">
             

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -19,6 +19,7 @@
         <h2 class=title>{{$post->title}}</h2>
         </a>
         <h3 class=body>{{$post->body}}</h3>
+        <h4>{{$post->category->name}}</h4>
         
         <a href="/posts/{{$post->id}}/edit">編集</a>
         

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -16,6 +16,8 @@
         
         <h3 class=body>{{$post->body}}</h3>
         
+        <h3 class=category>{{$post->category->name}}</h3>
+        
         <a href="/">back</a>
         
     </body>


### PR DESCRIPTION
## 変更の概要
* 変更の概要
カテゴリーの保存まで可能
カテゴリー別の画面はまだ

* 関連するIssueやプルリクエスト
#17 

## なぜこの変更をするのか
* 変更をする理由
写真のカテゴリー別機能を使えるようにするため

* 前提知識がなくても分かるようにする

## やったこと
* [x] やったこと
カテゴリーモデルの作成
カテゴリーテーブルの作成
ポストテーブルとのリレーション（ポストテーブルにcategory_idをついか）
カテゴリーモデルとポストモデルにリレーションのコードを追加
投稿作成画面でカテゴリー選択、保存可能にした


* [ ] やっていること
カテゴリー別の画面を実装

## 変更内容
* UIの変更ならスクリーンショット
* APIの変更ならリクエストとレスポンス

## 影響範囲
* ユーザーに影響すること
* メンバーに影響すること
* システムに影響すること

## どうやるのか
* 使い方
* 再現手順

## 課題
* 悩んでいること
* とくにレビューしてほしいところ

## 備考
* その他に伝えたいこと