### PR TITLE
feat#22投稿したユーザー名の表示と投稿作成時にユーザー保存

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -22,7 +22,8 @@ class PostController extends Controller
     }
     
     public function store(PostRequest $request,Post $post){
-        
+
+        $post->user_id = \Auth::id();
         $input = $request['post'];
         $post->fill($input)->save();
         return redirect('/posts/'.$post->id); 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -19,6 +19,10 @@ class Post extends Model
         return $this->belongsTo(Category::class);
     }
     
+    public function user(){
+        return $this->belongsTo(User::class);
+    }
+    
     protected $fillable=[
         'title',
         'body',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,4 +41,8 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+    
+    public function posts(){
+        return $this->hasMany(Post::class);
+    }
 }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,7 +20,9 @@ return new class extends Migration
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();
-            $table->timestamps();
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent();
+            $table->softDeletes();
         });
     }
 

--- a/database/migrations/2023_12_16_083005_add_user_id_to_posts_table.php
+++ b/database/migrations/2023_12_16_083005_add_user_id_to_posts_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::table('posts', function (Blueprint $table) {
             //onDelete('cascade')で反映されるのは物理削除のみ。論理削除の場合は投稿は削除されない。
-            $table->foreignId('category_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
         });
     }
 
@@ -28,8 +28,7 @@ return new class extends Migration
     {
         Schema::table('posts', function (Blueprint $table) {
             //
-            $table->dropForeign('posts_category_id_foreign');
-            $table->dropColumn('category_id');
+            $table->dropColumn('user_id');
         });
     }
 };

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,7 +20,8 @@ class DatabaseSeeder extends Seeder
         //     'name' => 'Test User',
         //     'email' => 'test@example.com',
         // ]);
+        $this->call(CategorySeeder::class);
         $this->call(PostSeeder::class);
-        $this->call(CategorySeedr::class);
+        
     }
 }

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -18,28 +18,33 @@ class PostSeeder extends Seeder
         DB::table('posts')->insert([
             'title'=>'ポケモン',
             'body'=>'ダウンロードコンテンツがもうすぐ発売です！',
-            'category_id'=>1
+            'category_id'=>1,
+            'user_id'=>1,
             ]);
         
         DB::table('posts')->insert([
             'title'=>'イチョウ',
             'body'=>'この前イチョウ並木を見てきました。圧巻！！',
-            'category_id'=>2
+            'category_id'=>2,
+            'user_id'=>1,
             ]);
         DB::table('posts')->insert([
             'title'=>'ひまわり',
             'body'=>'夏のひまわり畑が素敵でした',
-            'category_id'=>3
+            'category_id'=>3,
+            'user_id'=>1,
             ]);
         DB::table('posts')->insert([
             'title'=>'さくら',
             'body'=>'千葉公園の桜がとてもきれいでした',
-            'category_id'=>2
+            'category_id'=>2,
+            'user_id'=>1,
             ]);
         DB::table('posts')->insert([
             'title'=>'イルミネーション',
             'body'=>'六本木に初上陸。イルミネーションにみんな見とれていました。',
-            'category_id'=>3
+            'category_id'=>3,
+            'user_id'=>1,
             ]);
         
     }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -44,4 +44,9 @@
             </x-primary-button>
         </div>
     </form>
+    <div class="flex justify-end mt-4">
+    @if (Route::has('register'))
+            <a href="{{ route('register') }}" class="ml-4 text-sm text-gray-700 dark:text-gray-500 underline">Register</a>
+    @endif
+    </div>
 </x-guest-layout>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -23,26 +23,31 @@
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900">
-        <h1>Blog Name</h1>
-        <a href="/posts/create">新しい投稿を作成</a>
-        @foreach($posts as $post)
-        <a href="/posts/{{$post->id}}">
-        <h2 class=title>{{$post->title}}</h2>
-        </a>
-        <h3 class=body>{{$post->body}}</h3>
-        <a href="/categories/{{$post->category->id}}">
-        <h4>{{$post->category->name}}</h4>
-        </a>
-        <a href="/posts/{{$post->id}}/edit">編集</a>
-        
-        <form id="{{$post->id}}" action="/posts/{{$post->id}}/delete" method="POST">
-            @csrf
-            @method('DELETE')
-            <button type="button" onclick="deletePost({{$post->id}})">削除</button>
-            <!--deletePost({{$post->id}})で投稿のidを持った状態でjavascriptの関数が動く-->
-        </form>
-        @endforeach
-        
+                        <h1>Home</h1>
+                        <a href="/posts/create">新しい投稿を作成</a>
+                        @foreach($posts as $post)
+                            <div class="mt-6">
+                                <a href="/posts/{{$post->id}}">
+                                    <h2 class=title>{{$post->title}}</h2>
+                                </a>
+                                    <h3 class=body>{{$post->body}}</h3>
+                                <a href="/categories/{{$post->category->id}}">
+                                    <h4>{{$post->category->name}}</h4>
+                                </a>
+                                <div class="flex justify-end mt-4">
+                                    <p class=user>投稿者：{{$post->user->name}}</p>
+                                </div>
+                                <a href="/posts/{{$post->id}}/edit">編集</a>
+                                
+                                <form id="{{$post->id}}" action="/posts/{{$post->id}}/delete" method="POST">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="button" onclick="deletePost({{$post->id}})">削除</button>
+                                    <!--deletePost({{$post->id}})で投稿のidを持った状態でjavascriptの関数が動く-->
+                                </form>
+                            </div>
+                        @endforeach
+                            
        
         
                     </div>


### PR DESCRIPTION
## 変更の概要
* 変更の概要
ユーザー名を投稿に表示させたり保存できるようにした

* 関連するIssueやプルリクエスト
#22 

## なぜこの変更をするのか
* 変更をする理由
投稿者がわかることで、その投稿者の関連写真などを検索できるようにするため

## やったこと、学んだこと
1対多のリレーションは基本的には難しくない。
多の方からデータを取り出すときは少し確認が必要
投稿保存のときに必ずしもcreateに項目がないといけないわけではない。
ただ、あれで保存できている理屈は理解しきれていない感がある（fillしているのは$inputについて…？）
⇒fillのこと要確認
今回はAuth::id()というのを使った。あとでURLをコメントに追記しようと思う。

## 変更内容
* UIの変更ならスクリーンショット
* APIの変更ならリクエストとレスポンス

## 影響範囲
* ユーザーに影響すること
* メンバーに影響すること
* システムに影響すること

## 課題、疑問
* 悩んでいること
* とくにレビューしてほしいところ
