### PR TITLE
fix:投稿作成や編集画面などのレイアウトの修正

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -24,14 +24,18 @@ class PostController extends Controller
     public function store(PostRequest $request,Post $post){
 
         $post->user_id = \Auth::id();
+        //https://newmonz.jp/lesson/laravel-basic/chapter-8
+        //このサイトのユーザーid保存の項目の1行を追加。
         $input = $request['post'];
         $post->fill($input)->save();
+        //fillはあくまでカラムの内容を更新するだけ。
+        //user_idについてはその前の行で追加しているからsaveまでいける。
         return redirect('/posts/'.$post->id); 
         
     }
     
-    public function edit(Post $post){
-        return view('posts.edit')->with(['post'=>$post]);
+    public function edit(Category $category,Post $post){
+        return view('posts.edit')->with(['post'=>$post])->with(['categories'=>$category->get()]);
     }
     
     public function update(PostRequest $request,Post $post){

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -34,8 +34,8 @@ class PostRequest extends FormRequest
     public function attributes()
     {
     return [
-        'post.title' => 'タイトル',
-        'post.body' => '本文'
+        'post.title' => '投稿タイトル',
+        'post.body' => '写真説明'
     ];
     }
 }

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('index') }}
+        </h2>
+    <!--navigation.blade.phpからナビゲーションバーの項目を追加できる-->
+    </x-slot>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,30 +19,45 @@
     </head>
     
     <body>
-        <h1>Blog Name</h1>
-        <a href="/posts/create">create</a>
-        @foreach($posts as $post)
-        <a href="/posts/{{$post->id}}">
-        <h2 class=title>{{$post->title}}</h2>
-        </a>
-        <h3 class=body>{{$post->body}}</h3>
-        <h4>{{$post->category->name}}</h4>
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <h1>Home</h1>
+                        <a href="/posts/create">新しい投稿を作成</a>
+                        @foreach($posts as $post)
+                            <div class="mt-6">
+                                <a href="/posts/{{$post->id}}">
+                                    <h2 class=title>{{$post->title}}</h2>
+                                </a>
+                                    <h3 class=body>{{$post->body}}</h3>
+                                <a href="/categories/{{$post->category->id}}">
+                                    <h4>{{$post->category->name}}</h4>
+                                </a>
+                                <div class="flex justify-end mt-4">
+                                    <p class=user>投稿者：{{$post->user->name}}</p>
+                                </div>
+                                <a href="/posts/{{$post->id}}/edit">編集</a>
+                                
+                                <form id="{{$post->id}}" action="/posts/{{$post->id}}/delete" method="POST">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="button" onclick="deletePost({{$post->id}})">削除</button>
+                                    <!--deletePost({{$post->id}})で投稿のidを持った状態でjavascriptの関数が動く-->
+                                </form>
+                            </div>
+                        @endforeach
+                            
+       
         
-        <a href="/posts/{{$post->id}}/edit">編集</a>
-        
-        <form id="{{$post->id}}" action="/posts/{{$post->id}}/delete" method="POST">
-            @csrf
-            @method('DELETE')
-            <button type="button" onclick="deletePost({{$post->id}})">削除</button>
-            <!--deletePost({{$post->id}})で投稿のidを持った状態でjavascriptの関数が動く-->
-        </form>
-        @endforeach
-        
-        {{ $posts->links() }}
-        
+                    </div>
+                </div>
+            </div>
+        </div>
+         {{ $posts->links() }}
         <script>
             function deletePost($id){
-                var del = window.confirm("削除すると復元できません。本当に削除しますか。");
+                var del = window.confirm("本当に削除しますか。");
                 if(del){
                     document.getElementById($id).submit();
                 }
@@ -43,4 +65,5 @@
         </script>
         <!--受けっとったidは$idで書くことで関数を動かす-->
     </body>
+    </x-app-layout>
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -5,22 +5,19 @@
             <div class="flex">
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
-                    <a href="{{ route('dashboard') }}">
+                    <a href="{{ route('index') }}">
                         <x-application-logo class="block h-9 w-auto fill-current text-gray-800" />
                     </a>
                     
                 </div>
 
                 <!-- Navigation Links -->
-                <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
-                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Dashboard') }}
-                    </x-nav-link>
-                </div>
+                
                 <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
                     <x-nav-link :href="route('index')" :active="request()->routeIs('index')">
-                        {{ __('index') }}
+                        {{ __('投稿一覧') }}
                     </x-nav-link>
+                   
                 </div>
             </div>
 

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -1,5 +1,13 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('新規投稿作成') }}
+        </h2>
+    <!--navigation.blade.phpからナビゲーションバーの項目を追加できる-->
+    </x-slot>
+    
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -16,39 +24,48 @@
     </head>
     
     <body>
-        
-        <h1>Blog Name</h1>
-        
-        <form action="/posts" method="POST">
-        @csrf
-            <h2>タイトル</h2>
-            <input type="text" name="post[title]" value="{{ old('post.title') }}">
-            <p class="error">{{$errors->first('post.title')}}</p>
-            <!--
-            nameで指定した入れ子の構造（post[title]）は
-            それ以降は「.（ドット）」で繋いで取り出すことができる
-            -->
-            
-            <h2>本文</h2>
-            <textarea name="post[body]">{{ old('post.body') }}</textarea>
-            <p class="error">{{$errors->first('post.body')}}</p>
-            <!--
-            バリデーションのエラーメッセージのattributeはリクエストクラス（PostRequest）で指定できる
-            -->
-            <h2>カテゴリー</h2>
-            <select name="post[category_id]">
-                @foreach($categories as $category)
-                    <option value="{{$category->id}}">{{$category->name}}</option>
-                @endforeach
-            </select>
-            </br>
-            </br>
-            </br>
-            <input type="submit" value="保存">
-            
-        </form>
-        
-        <a href="/">back</a>
+       <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <form action="/posts" method="POST">
+                        @csrf
+                            <h2>投稿タイトル</h2>
+                            <input type="text" name="post[title]" value="{{ old('post.title') }}">
+                            <p class="error">{{$errors->first('post.title')}}</p>
+                            
+                            <!--
+                            nameで指定した入れ子の構造（post[title]）は
+                            それ以降は「.（ドット）」で繋いで取り出すことができる
+                            -->
+                            
+                            <h2>写真説明</h2>
+                            <textarea name="post[body]">{{ old('post.body') }}</textarea>
+                            <p class="error">{{$errors->first('post.body')}}</p>
+                            <!--
+                            バリデーションのエラーメッセージのattributeはリクエストクラス（PostRequest）で指定できる
+                            -->
+                            <h2>カテゴリー</h2>
+                            <select name="post[category_id]">
+                                @foreach($categories as $category)
+                                    <option value="{{$category->id}}">{{$category->name}}</option>
+                                @endforeach
+                            </select>
+                            </br>
+                            </br>
+                            </br>
+                            <x-primary-button class="ml-3">
+                                {{ __('保存') }}
+                            </x-primary-button>
+                            
+                        </form>
+                        
+                        <a href="/">back</a>
+                     </div>
+                </div>
+            </div>
+        </div>
         
     </body>
+    </x-app-layout>
 </html>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,38 +1,104 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('投稿内容の編集') }}
+        </h2>
+    <!--navigation.blade.phpからナビゲーションバーの項目を追加できる-->
+    </x-slot>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <title>Laravel</title>
+        
+        <style>
+            .error{
+                color:red;
+                font-weight:bold
+            }
+        </style>
 
         
     </head>
     
-    <body>
+    <body onload="selected({{$post->category_id}})">
         
-        <h1>Blog Name</h1>
-        
-        <form action="/posts/{{$post->id}}/edit" method="POST">
-        @csrf
-        @method('PUT')
-            <h2>タイトル</h2>
-            <input type="text" name="post[title]" value="{{ old('post.title',$post->title) }}">
-            <p>{{$errors->first('post.title')}}</p>
-            <!--
-            nameで指定した入れ子の構造（post[title]）は
-            それ以降は「.（ドット）」で繋いで取り出すことができる
-            -->
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <form action="/posts/{{$post->id}}/edit" method="POST">
+                        @csrf
+                        @method('PUT')
+                            <h2>投稿タイトル</h2>
+                            <input type="text" name="post[title]" value="{{ old('post.title',$post->title) }}">
+                            <p class="error">{{$errors->first('post.title')}}</p>
+                            <!--
+                            nameで指定した入れ子の構造（post[title]）は
+                            それ以降は「.（ドット）」で繋いで取り出すことができる
+                            -->
+                            
+                            <h2>写真説明</h2>
+                            <textarea name="post[body]">{{ old('post.body',$post->body) }}</textarea>
+                            <p class="error">{{$errors->first('post.body')}}</p>
+                            
+                            <h2>カテゴリー</h2>
+                            <select id="category" name="post[category_id]">
+                               
+                                 @foreach($categories as $category)
+                                    <option value="{{$category->id}}">{{$category->name}}</option>
+                                @endforeach
+                                
+                                <!--
+                                <option value=1>動物</option>
+                                <option value=2>乗り物</option>
+                                <option value=3>自然</option>
+                                <option value="{{$post->category_id}}" selected>{{$post->category->name}}</option>
+                                -->
+                            </select>
+                            </br>
+                            <x-primary-button class="ml-3">
+                                {{ __('保存') }}
+                            </x-primary-button>
+                            
+                        </form>
+                        
+                        <a href="/">back</a>
+                     </div>
+                </div>
+            </div>
+        </div>
+        <script>
+            function selected(id){
+                select = document.getElementById('category').options;
+                
+                for(let i = 0; i < select.length; i++){
+                    if(select[i].value == id){
+                        select[i].selected = true;
+                        break;
+                    }
+                    //select[i].value == idのところは===にすると動かない
+                    //厳密一致にするとダメな理由はわからない
+                }
+            }
             
-            <h2>本文</h2>
-            <textarea name="post[body]">{{ old('post.body',$post->body) }}</textarea>
-            <p>{{$errors->first('post.body')}}</p>
-            </br>
-            <input type="submit" value="保存">
-            
-        </form>
+           
+        /*
+             window.onload = function() {
+                select = document.getElementById('category').options;
+                for(let i = 0; i < select.length; i++ ){
+                    if(select[i].value === '3'){
+                        select[i].selected = true;
+                        break;
+                    }
+                }
+            }   
         
-        <a href="/">back</a>
-        
+        */    
+        </script>
     </body>
+    
+    </x-app-layout>
 </html>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -3,7 +3,7 @@
     <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('index') }}
+            {{ __('投稿一覧') }}
         </h2>
     <!--navigation.blade.phpからナビゲーションバーの項目を追加できる-->
     </x-slot>
@@ -13,8 +13,18 @@
 
         <title>Laravel</title>
 
-        <!-- Fonts -->
-        <link href="https://fonts.bunny.net/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+        
+        
+        <style>
+            
+            div.post{
+                padding: 10px;
+                margin: 10px;
+                border: 1px solid gray;
+                border-radius: 10px;
+            }
+            
+        </style>
 
     </head>
     
@@ -23,10 +33,12 @@
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900">
-                        <h1>Home</h1>
-                        <a href="/posts/create">新しい投稿を作成</a>
+                        <x-primary-button class="ml-3">
+                            <a href="/posts/create" class="newPost">新しい投稿を作成</a>
+                        </x-primary-button>
+                        
                         @foreach($posts as $post)
-                            <div class="mt-6">
+                            <div class="post">
                                 <a href="/posts/{{$post->id}}">
                                     <h2 class=title>{{$post->title}}</h2>
                                 </a>
@@ -37,13 +49,15 @@
                                 <div class="flex justify-end mt-4">
                                     <p class=user>投稿者：{{$post->user->name}}</p>
                                 </div>
-                                <a href="/posts/{{$post->id}}/edit">編集</a>
+                                    <a href="/posts/{{$post->id}}/edit">編集</a>
                                 
                                 <form id="{{$post->id}}" action="/posts/{{$post->id}}/delete" method="POST">
                                     @csrf
                                     @method('DELETE')
-                                    <button type="button" onclick="deletePost({{$post->id}})">削除</button>
+                                    
+                                    <button type="button" onclick="deletePost({{$post->id}})" class="mt-4">削除</button>
                                     <!--deletePost({{$post->id}})で投稿のidを持った状態でjavascriptの関数が動く-->
+                                    
                                 </form>
                             </div>
                         @endforeach
@@ -57,7 +71,7 @@
          {{ $posts->links() }}
         <script>
             function deletePost($id){
-                var del = window.confirm("削除すると復元できません。本当に削除しますか。");
+                var del = window.confirm("本当に削除しますか。");
                 if(del){
                     document.getElementById($id).submit();
                 }

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('投稿内容の詳細') }}
+        </h2>
+    <!--navigation.blade.phpからナビゲーションバーの項目を追加できる-->
+    </x-slot>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,15 +17,24 @@
     </head>
     
     <body>
-        <h1>Blog Name</h1>
-        
-        <h2 class=title>{{$post->title}}</h2>
-        
-        <h3 class=body>{{$post->body}}</h3>
-        
-        <h3 class=category>{{$post->category->name}}</h3>
-        
-        <a href="/">back</a>
-        
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <h2 class=title>{{$post->title}}</h2>
+                        
+                        <h3 class=body>{{$post->body}}</h3>
+                        
+                        <h3 class=category>{{$post->category->name}}</h3>
+                        <div class="flex justify-end mt-4">
+                            <p class=user>投稿者：{{$post->user->name}}</p>
+                        </div>
+                        
+                        <a href="/">back</a>
+                    </div>
+                </div>
+            </div>
+        </div>
     </body>
+    </x-app-layout>
 </html>


### PR DESCRIPTION
## 変更の概要
* 変更の概要
各ページにLaravelのレイアウトを反映させた。
投稿編集画面でカテゴリーの変更をできるように修正した。

* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
* 変更をする理由
見た目が統一されていると見やすい。
カテゴリーの変更もあり得るため。

## やったこと、学んだこと
Javascriptを使って投稿編集画面でのカテゴリー選択がもともと選んでいたカテゴリーが最初に選択されている状態になるようにできた。
selectの項目にidを付けてそれをjavascriptで取得して、optionの内容を配列として代入。
その配列のvalueが投稿のidと合うまでforで繰り返しをつくり、合えばそれをselectedとして返すみたいなかんじ。

cssの書き方も少しわかった。

## 変更内容
* UIの変更ならスクリーンショット
* APIの変更ならリクエストとレスポンス

## 影響範囲
* ユーザーに影響すること
* メンバーに影響すること
* システムに影響すること

## 課題、疑問
* 悩んでいること
cssがうまく適用されない。文字の色は反映されるが、背景の色などを指定すると表示されない。
もともとのレイアウトが優先されている？
* とくにレビューしてほしいところ
