### PR TITLE
feat#28お気に入りした投稿の一覧を表示

### DIFF
--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Post;
 use App\Models\Favorite;
+use App\Models\Category;
 
 class FavoriteController extends Controller
 {
@@ -12,16 +13,23 @@ class FavoriteController extends Controller
     public function favorite(Favorite $favorite, Post $post, Request $request){
         
         $favorite -> post_id = $post -> id;
-        $favorite -> user_id=\Auth::user() -> id;
+        $favorite -> user_id = \Auth::user() -> id;
         $favorite -> save();
         return back();
     }
     
     //お気に入り削除
     public function unfavorite(Post $post, Request $request){
-        $user=\Auth::user()->id;
-        $favorite=Favorite::where('post_id', $post->id)->where('user_id', $user)->first();
-        $favorite->delete();
+        $user = \Auth::user() -> id;
+        $favorite = Favorite::where( 'post_id', $post->id ) -> where( 'user_id', $user ) -> first();
+        $favorite -> delete();
         return back();
+    }
+    
+    //お気に入りした投稿一覧取得　https://newmonz.jp/lesson/laravel-basic/chapter-9　「ブックマークした記事一覧を取得」を参考
+    public function favorite_posts(Category $category){
+        $post = \Auth::user() -> posts() -> orderBy( 'updated_at', 'desc' ) -> paginate(3);
+    
+        return view('favorites.index') -> with(['posts'=>$post])-> with(['categories' => $category -> get()]);;
     }
 }

--- a/app/Models/Favorite.php
+++ b/app/Models/Favorite.php
@@ -16,4 +16,5 @@ class Favorite extends Model
     public function post(){
         return $this -> belongsTo(Post::class);
     }
+    
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -18,11 +18,15 @@ class Post extends Model
     }
     
     public function category(){
-        return $this->belongsTo(Category::class);
+        return $this -> belongsTo(Category::class);
     }
     
     public function user(){
-        return $this->belongsTo(User::class);
+        return $this -> belongsTo(User::class);
+    }
+    
+    public function users(){
+        return $this -> belongsToMany(User::class,'favorites');
     }
     
     public function favorites(){
@@ -34,18 +38,16 @@ class Post extends Model
         //投稿データを全件取得
         $query = self::query();
         
-        //投稿検索(キーワード)
+        //投稿検索(キーワード) https://qiita.com/hinako_n/items/7729aa9fec522c517f2a
         if (!empty($keyword)) {
             $query->where('title', 'LIKE', "%{$keyword}%")
                   ->orWhere('body', 'LIKE', "%{$keyword}%");
         }
-        // https://qiita.com/hinako_n/items/7729aa9fec522c517f2a
         
-        //投稿検索（カテゴリー）
+        //投稿検索（カテゴリー） https://qiita.com/hinako_n/items/96584b4a641097c753c7
         if (!empty($categoryId)) {
             $query->where('category_id', 'LIKE', $categoryId);
         }
-        // https://qiita.com/hinako_n/items/96584b4a641097c753c7
         
         return $query->orderBy('updated_at', 'desc')->paginate($pagination);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -43,7 +43,7 @@ class User extends Authenticatable
     ];
     
     public function posts(){
-        return $this->hasMany(Post::class);
+        return $this->belongsToMany(Post::class,'favorites');
     }
     
     public function favorites(){

--- a/resources/views/favorites/index.blade.php
+++ b/resources/views/favorites/index.blade.php
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('お気に入り投稿一覧') }}
+        </h2>
+    <!--navigation.blade.phpからナビゲーションバーの項目を追加できる-->
+    </x-slot>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <title>Laravel</title>
+
+        
+        
+        <style>
+            
+            div.post{
+                padding: 10px;
+                margin: 10px;
+                border: 1px solid gray;
+                border-radius: 10px;
+            }
+            
+        </style>
+
+    </head>
+    
+    <body>
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        
+                        
+                        <!-- 新規投稿機能ここから -->
+                        <x-primary-button class="ml-3 mt-6">
+                            <a href="{{ route('create') }}" class="newPost">新しい投稿を作成</a>
+                        </x-primary-button>
+                        
+                        <!-- 投稿一覧表示ここから -->
+                        @foreach($posts as $post)
+                            <div class="post">
+                                <a href="/posts/{{$post->id}}">
+                                    <h2 class=title>{{$post->title}}</h2>
+                                </a>
+                                    <h3 class=body>{{$post->body}}</h3>
+                                <a href="/categories/{{$post->category->id}}">
+                                    <h4>{{$post->category->name}}</h4>
+                                </a>
+                                <div class="flex justify-end mt-4">
+                                    <p class=user>投稿者：{{$post->user->name}}</p>
+                                </div>
+                                
+                                <!-- お気に入り機能ここから -->
+                                <!--https://biz.addisteria.com/laravel_nice_button/-->
+                                <span>
+                                    <!-- もし$favoriteがあれば＝ユーザーが「いいね」をしていたら -->
+                                    @if( $post -> is_favorited() )
+                                    
+                                    <!-- 「いいね」取消用ボタンを表示 -->
+                                    	<a href="{{ route('unfavorite', $post) }}" class="btn btn-success btn-sm">
+                                    		いいね取り消し
+                                    		<!-- 「いいね」の数を表示 -->
+                                    		<span class="badge">
+                                    			{{ $post->favorites->count() }}
+                                    		</span>
+                                    	</a>
+                                    @else
+                                    <!-- まだユーザーが「いいね」をしていなければ、「いいね」ボタンを表示 -->
+                                    	<a href="{{ route('favorite', $post) }}" class="btn btn-secondary btn-sm">
+                                    		いいね
+                                    		<!-- 「いいね」の数を表示 -->
+                                    		<span class="badge">
+                                    			{{ $post->favorites->count() }}
+                                    		</span>
+                                    	</a>
+                                    @endif
+                                </span>
+                                
+                                </br>
+                                <a href="/posts/{{$post->id}}/edit">編集</a>
+                                
+                                <form id="{{$post->id}}" action="/posts/{{$post->id}}/delete" method="POST">
+                                    @csrf
+                                    @method('DELETE')
+                                    
+                                    <button type="button" onclick="deletePost({{$post->id}})" class="mt-4">削除</button>
+                                    <!--deletePost({{$post->id}})で投稿のidを持った状態でjavascriptの関数が動く-->
+                                    
+                                </form>
+                            </div>
+                        @endforeach
+                            
+       
+        
+                    </div>
+                </div>
+            </div>
+        </div>
+         
+         {{$posts->appends(request()->query())->links()}}
+         <!--https://qiita.com/wbraver/items/b95814d6383172b07a58-->
+         
+         
+         <!-- 削除機能のポップアップここから -->
+        <script>
+            function deletePost($id){
+                var del = window.confirm("本当に削除しますか。");
+                if(del){
+                    document.getElementById($id).submit();
+                }
+            }
+        </script>
+        <!--受けっとったidは$idで書くことで関数を動かす-->
+        
+        
+    </body>
+    </x-app-layout>
+</html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -17,6 +17,9 @@
                     <x-nav-link :href="route('index')" :active="request()->routeIs('index')">
                         {{ __('投稿一覧') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('index_favorites')" :active="request()->routeIs('index_favorites')">
+                        {{ __('お気に入り一覧') }}
+                    </x-nav-link>
                    
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,28 +17,29 @@ use App\Http\Controllers\FavoriteController;
 |
 */
 
-Route::get('/',[PostController::class,'index'])->name('index')->middleware('auth');
+Route::get('/',[PostController::class,'index']) -> name('index') -> middleware('auth');
 //最後にmiddlewareを入れることでログイン済みでないとログイン画面に戻る　https://naoya-ono.com/blog/laravel-auth/
 
-Route::controller(PostController::class)->middleware('auth')->group(function(){
-    Route::get('/','index')->name('index'); //一覧画面
-    Route::get('/posts/create','create')->name('create'); //新規投稿作成
-    Route::get('/posts/{post}','show')->name('show'); //投稿詳細
-    Route::post('/posts','store')->name('store'); //新規投稿保存
-    Route::get('/posts/{post}/edit','edit')->name('edit'); //投稿編集
-    Route::put('/posts/{post}/edit','update')->name('update'); //投稿編集保存
+Route::controller(PostController::class) -> middleware('auth') -> group(function(){
+    Route::get('/','index') -> name('index'); //一覧画面
+    Route::get('/posts/create','create') -> name('create'); //新規投稿作成
+    Route::get('/posts/{post}','show') -> name('show'); //投稿詳細
+    Route::post('/posts','store') -> name('store'); //新規投稿保存
+    Route::get('/posts/{post}/edit','edit') -> name('edit'); //投稿編集
+    Route::put('/posts/{post}/edit','update') -> name('update'); //投稿編集保存
     //データの取得と送信の双方でのやり取りがあるputの時はURLをgetと同じにする必要がある？
-    Route::delete('/posts/{post}/delete','delete')->name('delete'); //投稿削除
+    Route::delete('/posts/{post}/delete','delete') -> name('delete'); //投稿削除
 });
 //ルートをまとめることはこのサイト https://nextat.co.jp/staff/archives/279
 //間にmiddleware('auth')を挟むと認証済みかどうかも組み込める
 
-Route::get('/categories/{category}',[CategoryController::class,'index'])->middleware('auth'); //カテゴリー別投稿一覧
+Route::get('/categories/{category}',[CategoryController::class,'index']) -> middleware('auth'); //カテゴリー別投稿一覧
 
 //お気に入り機能
-Route::controller(FavoriteController::class)->middleware('auth')->group(function(){
-    Route::get('/post/{post}/favorite','favorite')->name('favorite');
-    Route::get('/post/{post}/unfavorite','unfavorite')->name('unfavorite');
+Route::controller(FavoriteController::class) -> middleware( 'auth' )-> group( function(){
+    Route::get('/posts/{post}/favorite','favorite') -> name('favorite');
+    Route::get('/posts/{post}/unfavorite','unfavorite') -> name('unfavorite');
+    Route::get('/favorites','favorite_posts') -> name('index_favorites');
 });
     
 


### PR DESCRIPTION
## 変更の概要
* 変更の概要
お気に入りした投稿を取得して表示できるようにした

* 関連するIssueやプルリクエスト
#28 

## なぜこの変更をするのか
* 変更をする理由
お気に入りした投稿のみを確認出来るようにするため

## やったこと、学んだこと
リレーションをさせていると思ったより簡単にデータを取り出せる
理屈の理解が難しい
適宜休憩とってちゃんと調べなおすこと

## 課題、疑問
* 悩んでいること
イメージするお気に入りボタンはページの移動がない。javascriptだと思うが、根本的に作り直す必要ありそうで心配。

* とくにレビューしてほしいところ
