### PR TITLE
refactor:お気に入り状態の判定の処理をシンプルにした

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -53,19 +53,10 @@ class Post extends Model
     }
     
     //お気に入り状態の判別 https://qiita.com/phper_sugiyama/items/9a4088d1ca816a7e3f29
-    public function is_favorited(){
+    public function is_favorited($post){
         $id = \Auth::id();
 
-        $favoriters = array();
-        foreach($this->favorites as $favorite) { //$this->favoritesでfavoritesテーブルからpost_idで絞り込みされた配列が取り出されている？
-            array_push($favoriters, $favorite->user_id);
-        }
-        
-        if (in_array($id, $favoriters)) {
-            return true;
-        } else {
-            return false;
-        }
+        return $favorite=Favorite::where('post_id', $post->id)->where('user_id', auth()->user()->id)->exists();
     }
     
     protected $fillable=[

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -71,7 +71,7 @@
                                 <!--https://biz.addisteria.com/laravel_nice_button/-->
                                 <span>
                                     <!-- もし$favoriteがあれば＝ユーザーが「いいね」をしていたら -->
-                                    @if( $post -> is_favorited() )
+                                    @if( $post -> is_favorited($post) )
                                     
                                     <!-- 「いいね」取消用ボタンを表示 -->
                                     	<a href="{{ route('unfavorite', $post) }}" class="btn btn-success btn-sm">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -31,29 +31,27 @@
                         </div>
                         
                         <span>
-                                    <img src="{{asset('img/nicebutton.png')}}" width="30px">
-                                     
-                                    <!-- もし$favoriteがあれば＝ユーザーが「いいね」をしていたら -->
-                                    @if($favorite)
-                                    <!-- 「いいね」取消用ボタンを表示 -->
-                                    	<a href="{{ route('unfavorite', $post) }}" class="btn btn-success btn-sm">
-                                    		いいね取り消し
-                                    		<!-- 「いいね」の数を表示 -->
-                                    		<span class="badge">
-                                    			{{ $post->favorites->count() }}
-                                    		</span>
-                                    	</a>
-                                    @else
-                                    <!-- まだユーザーが「いいね」をしていなければ、「いいね」ボタンを表示 -->
-                                    	<a href="{{ route('favorite', $post) }}" class="btn btn-secondary btn-sm">
-                                    		いいね
-                                    		<!-- 「いいね」の数を表示 -->
-                                    		<span class="badge">
-                                    			{{ $post->favorites->count() }}
-                                    		</span>
-                                    	</a>
-                                    @endif
-                                </span>
+                                
+                            <!-- もし$favoriteがあれば＝ユーザーが「いいね」をしていたら -->
+                            @if($post->is_favorited($post))
+                            <!-- 「いいね」取消用ボタンを表示 -->
+                            	<a href="{{ route('unfavorite', $post) }}" class="btn btn-success btn-sm">
+                                	いいね取り消し
+                                	<span class="badge">
+                            			{{ $post->favorites->count() }}
+                            		</span>
+                            	</a>
+                            @else
+                            <!-- まだユーザーが「いいね」をしていなければ、「いいね」ボタンを表示 -->
+                            	<a href="{{ route('favorite', $post) }}" class="btn btn-secondary btn-sm">
+                            		いいね
+                            		<!-- 「いいね」の数を表示 -->
+                                	<span class="badge">
+                                		{{ $post->favorites->count() }}
+                                	</span>
+                                </a>
+                            @endif
+                        </span>
                         
                         <a href="/">back</a>
                     </div>


### PR DESCRIPTION
## 変更の概要
* 変更の概要
お気に入り状態の判別に関する関数から繰り返し処理を抜いた

* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
* 変更をする理由
お気に入り数が増えると処理が重くなるため

## やったこと、学んだこと
view側からもメソッドの引数に変数を入れてあげればその変数をメソッドに引き渡せる

## 課題、疑問
* 悩んでいること
* とくにレビューしてほしいところ
