### PR TITLE
feat:タグを投稿ごとに表示（タグの追加、登録機能はまだ）

### DIFF
--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -30,6 +30,9 @@ class FavoriteController extends Controller
     public function favorite_posts(Category $category){
         $post = \Auth::user() -> posts() -> orderBy( 'updated_at', 'desc' ) -> paginate(3);
     
-        return view('favorites.index') -> with(['posts'=>$post])-> with(['categories' => $category -> get()]);;
+        return view('favorites.index')->with([
+            'posts' => $post,
+            'categories' => $category->get()
+            ]);
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -16,9 +16,14 @@ class PostController extends Controller
         $keyword = $request -> input('keyword');
         $categoryId = $request -> input('category_id');
         $pagination = 3;
+        $tag = $post->tags()->get();
         
-        return view('posts.index') -> with(['posts' => $post -> search($keyword,$categoryId,$pagination)]) //メソッドの引数に入れてあげればModelで引き継げる　https://qiita.com/satorunooshie/items/c4b8fa611d9de632381f
-                                    -> with(['categories' => $category -> get()]);
+        
+        return view('posts.index')->with([
+            'posts' => $post->search($keyword,$categoryId,$pagination), //メソッドの引数に入れてあげればModelで引き継げる　https://qiita.com/satorunooshie/items/c4b8fa611d9de632381f
+            'categories' => $category -> get(),
+            
+        ]);
     }
     
     //投稿詳細表示

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    //投稿につけられたタグ取得　https://newmonz.jp/lesson/laravel-basic/chapter-9　「ブックマークした記事一覧を取得」を参考
+    public function post_tags(Category $category){
+        $tag = $post->tags()->get();
+    
+        return view('favorites.index')->with([
+            'posts' => $post,
+            'categories' => $category->get()
+            ]);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -33,6 +33,10 @@ class Post extends Model
         return $this -> hasMany(Favorite::class);
     }
     
+    public function tags(){
+        return $this -> belongsToMany(Tag::class);
+    }
+    
     public static function search($keyword, $categoryId, $pagination)
     {
         //投稿データを全件取得
@@ -57,6 +61,13 @@ class Post extends Model
         $id = \Auth::id();
 
         return $favorite=Favorite::where('post_id', $post->id)->where('user_id', auth()->user()->id)->exists();
+    }
+    
+    public function post_tags($post){
+        $tags = $post->tags()->get();
+       
+        return $tags;
+        
     }
     
     protected $fillable=[

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    use HasFactory;
+    
+    public function posts(){
+        return $this -> belongsToMany(Post::class);
+    }
+}

--- a/database/migrations/2023_12_23_092243_create_tags_table.php
+++ b/database/migrations/2023_12_23_092243_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2023_12_23_093127_create_post_tag_table.php
+++ b/database/migrations/2023_12_23_093127_create_post_tag_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->onDelete('cascade');
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('post_tag');
+    }
+};

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -63,6 +63,9 @@
                                 <a href="/categories/{{$post->category->id}}">
                                     <h4>{{$post->category->name}}</h4>
                                 </a>
+                                @foreach($post->post_tags($post) as $tag)
+                                    <p>{{$tag->name}}</p>
+                                @endforeach
                                 <div class="flex justify-end mt-4">
                                     <p class=user>投稿者：{{$post->user->name}}</p>
                                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,9 +43,6 @@ Route::controller(FavoriteController::class) -> middleware( 'auth' )-> group( fu
     Route::get('/favorites','favorite_posts') -> name('index_favorites');
 });
 
-Route::get('/ranking', [RankController::class, 'index'])->name('ranking.index');
-    
-
 Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');


### PR DESCRIPTION
## 変更の概要
* 変更の概要
投稿ごとにタグ付けしたものを表示できるようにした

* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
* 変更をする理由
タグ付けしたものを見れるようにするため

## やったこと、学んだこと
多対多のリレーションを組んで、紐づけされたデータを持ってくる
お気に入りでも同じことをやっていたのでこれは簡単だった。

## 課題、疑問
* 悩んでいること
タグの登録どうやるのか
⇒たぶん2か所に保存する？タグのテーブルとリレーションさせたテーブル
⇒順番大事かも。先にタグのテーブルに登録、そのあとリレーションさせてるテーブルに登録とか

* とくにレビューしてほしいところ
