### PR TITLE
feat:#34タグの保存、更新、同じタグのついた投稿を取得

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -3,14 +3,16 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Post;
+use App\Models\Tag;
+use App\Models\Category;
 
 class TagController extends Controller
 {
-    //投稿につけられたタグ取得　https://newmonz.jp/lesson/laravel-basic/chapter-9　「ブックマークした記事一覧を取得」を参考
-    public function post_tags(Category $category){
-        $tag = $post->tags()->get();
-    
-        return view('favorites.index')->with([
+    //タグ毎の投稿一覧取得
+    public function index(Category $category,Tag $tag){
+        $post = $tag->posts()->orderBy( 'updated_at', 'desc' )->paginate(3);
+        return view('tags.index',compact('tag'))->with([
             'posts' => $post,
             'categories' => $category->get()
             ]);

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -12,4 +12,14 @@ class Tag extends Model
     public function posts(){
         return $this -> belongsToMany(Post::class);
     }
+    
+    public function tagCheck($selectedTags,$tag){
+        
+        foreach($selectedTags as $selectedTag){
+            if($selectedTag->id === $tag->id){
+                return true; 
+            }    
+        }    
+        
+    }
 }

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -51,6 +51,12 @@
                                     <option value="{{$category->id}}">{{$category->name}}</option>
                                 @endforeach
                             </select>
+                            
+                            <h2>タグ</h2>
+                            @foreach($tags as $tag)
+                                <input type="checkbox" name="tag[]" value="{{$tag->id}}"><label>{{$tag->name}}</label>
+                            @endforeach
+                            
                             </br>
                             </br>
                             </br>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -23,7 +23,7 @@
         
     </head>
     
-    <body onload="selected({{$post->category_id}})">
+    <body onload="selected({{$post->category_id}});selectedTag($selectedTags)">
     <!--
     このonloadでカテゴリーの初期値をもともと選択していたカテゴリーにする。
     下のほうにjavascriptが書いてある。
@@ -52,14 +52,23 @@
                             <h2>カテゴリー</h2>
                             <select id="category" name="post[category_id]">
                                
-                                 @foreach($categories as $category)
+                                @foreach($categories as $category)
                                     <option value="{{$category->id}}">{{$category->name}}</option>
                                 @endforeach
                                 
-                                
                             </select>
+                            
+                            <h2>tag</h2>
+                            @foreach($tags as $tag)
+                                <input type="checkbox" name="tag[]" value="{{$tag->id}}" <?=($tag->tagCheck($selectedTags,$tag))?"checked":"" ?>><label>{{$tag->name}}</label>
+                                <!--
+                                checkedの条件分岐の書き方参考 https://teratail.com/questions/237098
+                                <条件?"条件成立":"不成立">の書き方はjavascriptの書き方。両サイドのはてながわからない。
+                                -->
+                            @endforeach
+                            
                             </br>
-                            <x-primary-button class="ml-3">
+                            <x-primary-button class="mt-3">
                                 {{ __('保存') }}
                             </x-primary-button>
                             
@@ -86,27 +95,14 @@
                         break;
                     
                     }
-                //if文でselectに格納された配列に対して0から順に配列の中身のvalueについてidと一致するか検証※ここのidはcategor y_idのこと
+                //if文でselectに格納された配列に対して0から順にselectの中のvalueについてidと一致するか検証※ここのidはcategor y_idのこと
                 //一致すればtrueが返るのでif内の関数が実行される
                 //if内の関数はその時のselectの配列番号の内容をselected（初期値）にするという意味。
                 //参考：https://teratail.com/questions/123775
                 }
             }
-            
-           
-        /*
-             window.onload = function() {
-                select = document.getElementById('category').options;
-                for(let i = 0; i < select.length; i++ ){
-                    if(select[i].value === '3'){
-                        select[i].selected = true;
-                        break;
-                    }
-                }
-            }   
-        
-        */    
         </script>
+        
     </body>
     
     </x-app-layout>

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -3,7 +3,7 @@
     <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('投稿一覧') }}
+            {{$tag->name}}の投稿一覧
         </h2>
     <!--navigation.blade.phpからナビゲーションバーの項目を追加できる-->
     </x-slot>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\FavoriteController;
-use App\Http\Controllers\RankController;
+use App\Http\Controllers\TagController;
 
 /*
 |--------------------------------------------------------------------------
@@ -42,6 +42,8 @@ Route::controller(FavoriteController::class) -> middleware( 'auth' )-> group( fu
     Route::get('/posts/{post}/unfavorite','unfavorite') -> name('unfavorite');
     Route::get('/favorites','favorite_posts') -> name('index_favorites');
 });
+
+Route::get('/tags/{tag}',[TagController::class,'index']) -> middleware('auth');
 
 Route::get('/dashboard', function () {
     return view('dashboard');


### PR DESCRIPTION
## 変更の概要
* 変更の概要
新規投稿でタグを選んで保存
投稿一覧にタグを表示
投稿編集でタグも更新可能★
タグごとの投稿を取得
* 関連するIssueやプルリクエスト
#34 

## なぜこの変更をするのか
* 変更をする理由
タグつけすることでより細かい状況設定が可能になる。
複数のタグをつけることで同じような写真を探しやすくなる

## やったこと、学んだこと
基本的には多対多のリレーションなだけだったのでお気に入り機能と変わらなかった。
難しかったのは投稿編集でもともと選択されていたタグを最初からチェックが入っている状態にすること
⇒結果として書くコード自体はシンプルだったが、たどり着くのに苦労した。
⇒htmlにJavascriptを書くのにもいろいろ書き方があるみたいなので勉強になった。
多対多のテーブルの更新はめっちゃ便利なsync()というメソッドがあったので簡単だったが、
何が起きているのかは理解しておきたいと思う。

## 課題、疑問
* 悩んでいること
sync()メソッドで何が起きているのか
Javascriptの書き方
※全然別件だがカテゴリーの選択もタグと同じようにできそう。カテゴリーはJavascript使っているが、＝＝＝だと動かない理由を知りたい。
* とくにレビューしてほしいところ
