### PR TITLE
fix#34編集画面のタグとカテゴリーの初期値設定のコードを変更

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -61,13 +61,10 @@ class PostController extends Controller
     //投稿編集
     public function edit(Category $category,Post $post,Tag $tag){
         
-        $selectedTag=$post->tags()->get();
-        
         return view('posts.edit')->with([
             'post' => $post,
             'categories' => $category->get(),
             'tags' => $tag->get(),
-            'selectedTags' => $selectedTag,
         ]);
     }
     

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -63,6 +63,7 @@ class Post extends Model
         return $favorite=Favorite::where('post_id', $post->id)->where('user_id', auth()->user()->id)->exists();
     }
     
+    //投稿ごとのタグ取得
     public function post_tags($post){
         $tags = $post->tags()->get();
        

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -13,6 +13,7 @@ class Tag extends Model
         return $this -> belongsToMany(Post::class);
     }
     
+    //投稿編集画面でのタグの初期値設定
     public function tagCheck($selectedTags,$tag){
         
         foreach($selectedTags as $selectedTag){

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -23,7 +23,7 @@
         
     </head>
     
-    <body onload="selected({{$post->category_id}});selectedTag($selectedTags)">
+    <body>
     <!--
     このonloadでカテゴリーの初期値をもともと選択していたカテゴリーにする。
     下のほうにjavascriptが書いてある。
@@ -53,17 +53,23 @@
                             <select id="category" name="post[category_id]">
                                
                                 @foreach($categories as $category)
-                                    <option value="{{$category->id}}">{{$category->name}}</option>
+                                    <option value="{{$category->id}}"{{ $category->id === $post->category_id ? "selected":"" }}>{{$category->name}}</option>
                                 @endforeach
                                 
                             </select>
                             
                             <h2>tag</h2>
                             @foreach($tags as $tag)
-                                <input type="checkbox" name="tag[]" value="{{$tag->id}}" <?=($tag->tagCheck($selectedTags,$tag))?"checked":"" ?>><label>{{$tag->name}}</label>
+                                <input type="checkbox" name="tag[]" value="{{$tag->id}}" {{ in_array($tag->id, $post->tags->pluck('id')->toArray()) ? 'checked' : '' }}><label>{{$tag->name}}</label>
                                 <!--
-                                checkedの条件分岐の書き方参考 https://teratail.com/questions/237098
-                                <条件?"条件成立":"不成立">の書き方はjavascriptの書き方。両サイドのはてながわからない。
+                                {{in_array()?'checked':''}}これの?以降で場合分け。trueならchecked、falseなら''を返す
+                                in_array(探したい値, 配列)で配列の中に探したい値があればtrue、なければfalseを返す
+                                やりたいことは「このタグのidってこのポストが持つタグのidと一致してますか？」ということなので
+                                1.探したい値にこのタグのid、配列にこの投稿の持つタグのidを持ってくる
+                                2.この投稿の持つタグのidは$postでこの投稿を取得
+                                3.tagsでこの投稿が持つタグにアクセス、
+                                4.pluck('id')でアクセスした先のデータからidだけ取得 https://qiita.com/jacksuzuki/items/eae943735bda747be09c
+                                5.toArrayで配列に変換している。
                                 -->
                             @endforeach
                             
@@ -79,29 +85,7 @@
                 </div>
             </div>
         </div>
-        <script>
-            function selected(id){ 
-                //selected(id)のidはonloadのところでもらってきたcategory_idのこと
-                select = document.getElementById('category').options;
-                //htmlの方のセレクトボックスにつけたid='category'の内容を取得し、
-                //さらに.optionsでoptionの内容を取得。selectという値に配列として格納している。
-                
-                for(let i = 0; i < select.length; i++){
-                    if(select[i].value == id){
-                        //select[i].value == idのところは===にすると動かない
-                        //厳密一致(===)にするとダメな理由はわからない
-                        
-                        select[i].selected = true;
-                        break;
-                    
-                    }
-                //if文でselectに格納された配列に対して0から順にselectの中のvalueについてidと一致するか検証※ここのidはcategor y_idのこと
-                //一致すればtrueが返るのでif内の関数が実行される
-                //if内の関数はその時のselectの配列番号の内容をselected（初期値）にするという意味。
-                //参考：https://teratail.com/questions/123775
-                }
-            }
-        </script>
+        
         
     </body>
     


### PR DESCRIPTION
## 変更の概要
* 変更の概要
変数画面で、元から投稿で選択されていたカテゴリーやタグのチェックが初期値として設定されるようにした

* 関連するIssueやプルリクエスト
#34 

## なぜこの変更をするのか
* 変更をする理由
保守しやすいコードにするため
余計な動きを減らして、軽くするため

## やったこと、学んだこと
javascriptを使わずとも初期値の設定は実現できる
⇒html上で条件分岐の設定が可能
配列なのかどうかなどよく考える必要がある
foreachで回さずとも配列の中の配列の値を取り出すことは可能？（pluckを使う）

## 課題、疑問
* 悩んでいること
* とくにレビューしてほしいところ
