### PR TITLE
feat#41ユーザーフォロー機能の実装

### DIFF
--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -12,23 +12,23 @@ class FavoriteController extends Controller
     //お気に入り追加
     public function favorite(Favorite $favorite, Post $post, Request $request){
         
-        $favorite -> post_id = $post -> id;
-        $favorite -> user_id = \Auth::user() -> id;
-        $favorite -> save();
+        $favorite->post_id = $post->id;
+        $favorite->user_id = \Auth::user()->id;
+        $favorite->save();
         return back();
     }
     
     //お気に入り削除
     public function unfavorite(Post $post, Request $request){
-        $user = \Auth::user() -> id;
-        $favorite = Favorite::where( 'post_id', $post->id ) -> where( 'user_id', $user ) -> first();
+        $user = \Auth::user()->id;
+        $favorite = Favorite::where( 'post_id', $post->id )->where( 'user_id', $user )->first();
         $favorite -> delete();
         return back();
     }
     
     //お気に入りした投稿一覧取得　https://newmonz.jp/lesson/laravel-basic/chapter-9　「ブックマークした記事一覧を取得」を参考
     public function favorite_posts(Category $category){
-        $post = \Auth::user() -> posts() -> orderBy( 'updated_at', 'desc' ) -> paginate(3);
+        $post = \Auth::user() -> favorite_posts() -> orderBy( 'updated_at', 'desc' ) -> paginate(3);
     
         return view('favorites.index')->with([
             'posts' => $post,

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\User;
+use App\Models\Follow;
+use App\Models\Post;
+use App\Models\Category;
+
+
+class FollowController extends Controller
+{
+    public function follow(Follow $follow, User $user) {
+        
+        $follow->follower_id = \Auth::user()->id;
+        $follow->followee_id = $user->id;
+        $follow -> save();
+        return back();
+    }
+
+    public function unfollow(User $user) {
+        $follow = Follow::where('follower_id',\Auth::user()->id)->where('followee_id', $user->id)->first();
+        $follow->delete();
+        
+        return back();
+    }
+    
+    //フォロー中のユーザーの投稿一覧取得　https://newmonz.jp/lesson/laravel-basic/chapter-9　「ブックマークした記事一覧を取得」を参考
+    public function follows_posts(Category $category, Post $post){
+        $followee = Follow::where('follower_id',\Auth::user()->id)->get();
+        
+        $post = $post->where('user_id', $followee->pluck('followee_id'))->orderBy( 'updated_at', 'desc' )->paginate(3);
+        
+    
+        return view('favorites.index')->with([
+            'posts' => $post,
+            'categories' => $category->get()
+            ]);
+    }
+}

--- a/app/Models/Follow.php
+++ b/app/Models/Follow.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Follow extends Model
+{
+    use HasFactory;
+    
+    
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -71,6 +71,18 @@ class Post extends Model
         
     }
     
+    //フォロー状態の判別
+    public function is_followed($post){
+        $id = \Auth::id();
+
+        return $follow=Follow::where('follower_id', \Auth::user()->id)->where('followee_id', $post->user->id)->exists();
+    }
+    
+    //
+    public function follow_count($post){
+        return $count = \App\Models\Follow::where('followee_id', $post->user_id)->count();
+    }
+    
     protected $fillable=[
         'title',
         'body',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -42,11 +42,21 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
     
-    public function posts(){
+    public function favorite_posts(){
         return $this->belongsToMany(Post::class,'favorites');
     }
     
     public function favorites(){
         return $this -> hasMany(Favorite::class);
+    }
+    
+    public function followers()
+    {
+    return $this->belongsToMany('App\Models\User', 'follows', 'follower_id', 'followee_id');
+    }
+
+    public function followees()
+    {
+    return $this->belongsToMany('App\Models\User', 'follows', 'followee_id', 'follower_id');
     }
 }

--- a/database/migrations/2023_12_28_095529_create_follows_table.php
+++ b/database/migrations/2023_12_28_095529_create_follows_table.php
@@ -13,10 +13,11 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('posts', function (Blueprint $table) {
-            //
-            $table->double('latitude',9,7);
-            $table->double('longitude',10,7);
+        Schema::create('follows', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('follower_id')->constrained();
+            $table->foreignId('followee_id')->constrained();
+            $table->timestamps();
         });
     }
 
@@ -27,10 +28,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::table('posts', function (Blueprint $table) {
-            //
-            $table->dropColumn('latitude');
-            $table->dropColumn('longitude');
-        });
+        Schema::dropIfExists('follows');
     }
 };

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -20,6 +20,9 @@
                     <x-nav-link :href="route('index_favorites')" :active="request()->routeIs('index_favorites')">
                         {{ __('お気に入り一覧') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('index_follows')" :active="request()->routeIs('index_follows')">
+                        {{ __('フォロー中のユーザーの投稿') }}
+                    </x-nav-link>
                    
                 </div>
             </div>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -70,6 +70,24 @@
                                 @endforeach
                                 <div class="flex justify-end mt-4">
                                     <p class=user>投稿者：{{$post->user->name}}</p>
+                                    </br>
+                                    <p>フォロワー数：{{$post->follow_count($post)}}</p>
+                                    </br>
+                                    <!-- フォロー機能ここから -->
+                                    <span>
+                                        @if($post->user_id !== Auth::user()->id )
+                                            @if( $post->is_followed($post) )
+                                            	<a href = "{{ route('unfollow', $post->user_id) }}" class="btn btn-success btn-sm">
+                                            		フォロー解除
+                                            	</a>
+                                            @else
+                                            	<a href = "{{ route('follow', $post->user_id) }}" class="btn btn-secondary btn-sm">
+                                            		フォローする
+                                            	</a>
+                                            @endif
+                                        @endif
+                                        
+                                        </span>
                                 </div>
                                 
                                 <!-- お気に入り機能ここから -->

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -85,21 +85,21 @@
       let map;
       
       async function initMap($post) {
-        // The location of Uluru
+        
         const position = { lat: {{$post->latitude}}, lng: {{$post->longitude}} };
         // Request needed libraries.
         //@ts-ignore
         const { Map } = await google.maps.importLibrary("maps");
         const { AdvancedMarkerView } = await google.maps.importLibrary("marker");
       
-        // The map, centered at Uluru
+        // The map
         map = new Map(document.getElementById("map"), {
           zoom: 13,
           center: position,
           mapId: "MAP_ID",
         });
       
-        // The marker, positioned at Uluru
+        // The marker
         const marker = new AdvancedMarkerView({
           map: map,
           position: position,

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\PostController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\FavoriteController;
 use App\Http\Controllers\TagController;
+use App\Http\Controllers\FollowController;
+
 
 /*
 |--------------------------------------------------------------------------
@@ -44,6 +46,15 @@ Route::controller(FavoriteController::class) -> middleware( 'auth' )-> group( fu
 });
 
 Route::get('/tags/{tag}',[TagController::class,'index']) -> middleware('auth');
+
+Route::controller(FollowController::class) -> middleware( 'auth' )-> group( function(){
+    Route::get('/follows/{user}/follow','follow') -> name('follow');
+    Route::get('/follows/{user}/unfollow','unfollow') -> name('unfollow');
+    Route::get('/follows/posts','follows_posts') -> name('index_follows');
+});
+
+
+
 
 Route::get('/dashboard', function () {
     return view('dashboard');


### PR DESCRIPTION
## 変更の概要
* 変更の概要
ユーザーフォロー機能実装

* 関連するIssueやプルリクエスト
#41 

## なぜこの変更をするのか
* 変更をする理由
ユーザーが増えたときに好きな投稿者の投稿を見れるようにするため

## やったこと、学んだこと
基本はお気に入り機能の時と同じ。
多少リレーションの書き方などが違うところは苦戦したが、
データ取得、保存、画面の切り替えなどは同じような手順でできた。

## 課題、疑問
* 悩んでいること
プロフィールページの作成（そのユーザーのみの投稿が見れる、ユーザーの情報が見れる、そこからもフォローできる）

* とくにレビューしてほしいところ
