### PR TITLE
feat:お気に入り数の多い順に並び替えできるようにした（再掲）

### DIFF
--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -35,4 +35,5 @@ class FavoriteController extends Controller
             'categories' => $category->get()
             ]);
     }
+    
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -87,5 +87,12 @@ class PostController extends Controller
         return redirect('/');
     }
     
+    //お気に入り数順での投稿取得
+    public function favorite_rank(Post $post,Category  $category){
+        return view('favorites.rank')->with([
+            'posts' => $post->favorite_rank(),
+            'categories' => $category->get(),
+            ]);
+    }
     
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -56,25 +56,29 @@ class Post extends Model
             $query->whereHas('tags',function($q)use($tagsId){
                 $q->whereIn('post_tag.tag_id',$tagsId);
             });
-            }
-            
-        
-        
+        }
         
         return $query->orderBy('updated_at', 'desc')->paginate($pagination);
     }
     
-    //お気に入り状態の判別 https://qiita.com/phper_sugiyama/items/9a4088d1ca816a7e3f29
+    //その投稿のお気に入り状態の判別 https://qiita.com/phper_sugiyama/items/9a4088d1ca816a7e3f29
     public function is_favorited($post){
-        $id = \Auth::id();
+        $id = \Auth::id(); //これいらない？
 
         return $favorite=Favorite::where('post_id', $post->id)->where('user_id', auth()->user()->id)->exists();
     }
     
+    //お気に入り数の多い投稿順に取得
+    public function favorite_rank(){
+        $post = $this->withcount('favorites')->orderBy('favorites_count','desc')->paginate(3);
+        
+        return $post;
+    }
+    
+    
     //投稿ごとのタグ取得
     public function post_tags($post){
         $tags = $post->tags()->get();
-       
         return $tags;
         
     }

--- a/resources/views/favorites/rank.blade.php
+++ b/resources/views/favorites/rank.blade.php
@@ -51,8 +51,8 @@
                         <div>
                             <p>並び替え</p>
                             <a href = "/">投稿日時順</a>
-                            <u><a href = "/favorites/rank">お気に入り数順</a></u>
-                            <a href = "/posts/views/rank">閲覧数順</a>
+                            <u><a href = "/favorite/posts/rank">お気に入り数順</a></u>
+                        
                         </div>
                         <!-- 新規投稿機能ここから -->
                         <x-primary-button class="ml-3 mt-6">

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -51,6 +51,13 @@
                                 <input type="submit" value="検索">
                             </form>
                         </div>
+                        <!--並び替え機能ここから-->
+                        <div>
+                            <p>並び替え</p>
+                            <a href = "/">投稿日時順</a>
+                            <a href = "/favorite/posts/rank">お気に入り数順</a>
+                        
+                        </div>
                         <!-- 新規投稿機能ここから -->
                         <x-primary-button class="ml-3 mt-6">
                             <a href="{{ route('create') }}" class="newPost">新しい投稿を作成</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::controller(PostController::class)->middleware('auth')->group(function(){
     Route::put('/posts/{post}/edit','update')->name('update'); //投稿編集保存
     //データの取得と送信の双方でのやり取りがあるputの時はURLをgetと同じにする必要がある？
     Route::delete('/posts/{post}/delete','delete')->name('delete'); //投稿削除
+    Route::get('/favorite/posts/rank','favorite_rank')->name('favorite_rank');
 });
 //ルートをまとめることはこのサイト https://nextat.co.jp/staff/archives/279
 //間にmiddleware('auth')を挟むと認証済みかどうかも組み込める


### PR DESCRIPTION
## 変更の概要
* 変更の概要
並び替え機能としてお気に入り数順、更新日順の機能を実装

* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
* 変更をする理由
お気に入りが多い＝人気の投稿を調べられる

## やったこと、学んだこと
リレーション先のデータのカウントは結構簡単にできる

## 課題、疑問
* 悩んでいること
検索機能にこれを追加するか
（検索ワード+並び替え）
検索先でそのページ内のデータを並び替えできるかどうか

* とくにレビューしてほしいところ
