### PR TITLE
fix:戻るボタンの戻り先、投稿日の表示

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -65,6 +65,11 @@ class Post extends Model
         return $favorite=Favorite::where('post_id', $post->id)->where('user_id', auth()->user()->id)->exists();
     }
     
+    //
+    public function favorite_posts(){
+        return \Auth::user() -> favorite_posts() -> orderBy( 'updated_at', 'desc' ) -> paginate(3);
+    }
+    
     //お気に入り数の多い投稿順に取得
     public function favorite_rank(){
         $post = $this->withcount('favorites')->orderBy('favorites_count','desc')->paginate($this->paginate);

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -84,7 +84,7 @@
                                     <p>フォロワー数：{{$post->follow_count($post)}}</p>
                                     </br>
                                     <!-- フォロー機能ここから -->
-                                    <span>
+                                    <div>
                                         @if($post->user_id !== Auth::user()->id )
                                             @if( $post->is_followed($post) )
                                             	<a href = "{{ route('unfollow', $post->user_id) }}" class="btn btn-success btn-sm">
@@ -96,9 +96,13 @@
                                             	</a>
                                             @endif
                                         @endif
-                                        
-                                        </span>
+                                    </div>
+                                    
+                                    <p>
+                                        {{ $post->created_at->toDateString() }}
+                                    </p>
                                 </div>
+                                
                                 
                                 <!-- お気に入り機能ここから -->
                                 <!--https://biz.addisteria.com/laravel_nice_button/-->

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -40,9 +40,37 @@
           <h3 class=body>{{$post->body}}</h3>
                         
           <h3 class=category>{{$post->category->name}}</h3>
+          @foreach($post->post_tags($post) as $tag)
+              <a href="/tags/{{$tag->id}}">
+                  <p>{{$tag->name}}</p>
+              </a>
+          @endforeach
           <div class="flex justify-end mt-4">
-            <p class=user>投稿者：{{$post->user->name}}</p>
+            <a href={{ route('profile',$post->user_id) }}><p class=user>投稿者：{{$post->user->name}}</p></a>
+            </br>
+            <p>フォロワー数：{{$post->follow_count($post)}}</p>
+            </br>
+            <!-- フォロー機能ここから -->
+            <div>
+                @if($post->user_id !== Auth::user()->id )
+                    @if( $post->is_followed($post) )
+                    	<a href = "{{ route('unfollow', $post->user_id) }}" class="btn btn-success btn-sm">
+                    		フォロー解除
+                    	</a>
+                    @else
+                    	<a href = "{{ route('follow', $post->user_id) }}" class="btn btn-secondary btn-sm">
+                    		フォローする
+                    	</a>
+                    @endif
+                @endif
+                
+            </div>
+            
+            <p>
+              投稿日：{{ $post->created_at->toDateString() }}
+            </p>
           </div>
+          
                         
           <span>  
             <!-- もし$favoriteがあれば＝ユーザーが「いいね」をしていたら -->
@@ -66,7 +94,7 @@
             @endif
           </span>
                         
-          <a href="/">back</a>
+          <a href="{{url()->previous()}}">back</a>
           
           <div id="map" style="height:500px; width:800px;"></div>
           


### PR DESCRIPTION
## 変更の概要
* 変更の概要
戻るボタンの戻り先を直前に開いていたページに変更

* 関連するIssueやプルリクエスト


## なぜこの変更をするのか
* 変更をする理由
戻り先が毎回一覧ページになってしまっていたため。

## やったこと、学んだこと
結構簡単にできる

## 課題、疑問
* 悩んでいること
要確認：検索結果の方にも戻れるのか
* とくにレビューしてほしいところ
