### PR TITLE
chore:APIキーをenvファイルに移して表示できるようにした

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -30,5 +30,9 @@ return [
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
+    
+    'googleMap' => [
+      'apikey' => env('GOOGLE_MAP_API_KEY'),
+    ],
 
 ];

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -83,7 +83,7 @@
             </div>
         </div>
 
-        <script src="https://maps.googleapis.com/maps/api/js?key=APIKEY&callback=initAutocomplete&libraries=places&v=weekly"defer></script>
+        <script src="https://maps.googleapis.com/maps/api/js?key={{config('services.googleMap.apikey')}}&callback=initAutocomplete&libraries=places&v=weekly"defer></script>
 
         <script>
           function initAutocomplete() {

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -96,7 +96,7 @@
                 </div>
             </div>
         </div>
-        <script src="https://maps.googleapis.com/maps/api/js?key=APIKEY&callback=initAutocomplete&libraries=places&v=weekly"defer></script>
+        <script src="https://maps.googleapis.com/maps/api/js?key={{config('services.googleMap.apikey')}}&callback=initAutocomplete&libraries=places&v=weekly"defer></script>
 
         <script>
           function initAutocomplete($post) {

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -106,7 +106,7 @@
   
     <script>(g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})
 
-        ({key: "APIKEY", v: "beta"});</script>
+        ({key: "{{config('services.googleMap.apikey')}}", v: "beta"});</script>
 
     <script>
             // Initialize and add the map


### PR DESCRIPTION
## 変更の概要
* 変更の概要
APIきーを環境ファイルに設定し、公開せずに済むようにした

* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
* 変更をする理由
APIキーの公開はやってはいけない。従量課金である場合などもあるし、
APIキーを盗まれて不正に利用された場合、悪質なアカウントとして停止されたり、ユーザーの個人情報が盗まれたりする危険性もある

## やったこと、学んだこと
上記の通りだが、気を付けないといけない。
公開せずに環境ファイルに設定⇒取り出すのは簡単にできるから必ずやること。

## 課題、疑問
* 悩んでいること
* とくにレビューしてほしいところ
