### PR TITLE
eagerロードを各投稿取得に追加。

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -8,11 +8,12 @@ use App\Models\Category;
 
 class CategoryController extends Controller
 {
-    //
+    //カテゴリーごとの投稿取得
     public function index(Post $post, Category $category){
+        
         $header = $post->inRandomOrder()->first();
-        //$categoryにすでに指定したカテゴリーのcategory_idが格納されている。
-        //$categoryで指定したidについてgetCategoryPaginateを使ってデータを取得している
+        //view側でカテゴリー選択時にそのカテゴリーのcategory_idが$categoryに格納されている。
+        //getCategoryPaginateを使ってデータを取得している
         return view('categories.index',compact('header'))->with(['posts'=>$category->getCategoryPaginate()]);
         
         

--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -21,7 +21,7 @@ class FavoriteController extends Controller
     //お気に入り削除
     public function unfavorite(Post $post, Request $request){
         $user = \Auth::user()->id;
-        $favorite = Favorite::where( 'post_id', $post->id )->where( 'user_id', $user )->first();
+        $favorite = Favorite::where( 'post_id', $post->id )->where( 'user_id', $user )->first(); //post_idとuser_id両方に一致するfavoriteのrecordを取得
         $favorite -> delete();
         return back();
     }

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -28,9 +28,9 @@ class FollowController extends Controller
     
     //フォロー中のユーザーの投稿一覧取得　https://newmonz.jp/lesson/laravel-basic/chapter-9　「ブックマークした記事一覧を取得」を参考
     public function follows_posts(Category $category, Post $post){
-        $followee = Follow::where('follower_id',\Auth::user()->id)->get();
+        $followeeId = \Auth::user()->followers()->pluck('followee_id');
         
-        $post_follow = $post->whereIn('user_id', $followee->pluck('followee_id')->toArray())->orderBy( 'updated_at', 'desc' )->paginate(3);
+        $post_follow = $post->whereIn('user_id', $followeeId)->orderBy( 'updated_at', 'desc' )->paginate(9);
         $header = $post->inRandomOrder()->first();
     
         return view('posts.followees_posts_index',compact('header'))->with([

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -62,7 +62,7 @@ class ProfileController extends Controller
     
     public function profile(User $user, Post $post){
         $header = $post->inRandomOrder()->first();
-        $post_user = $post->where('user_id', $user->id)->orderBy( 'updated_at', 'desc' )->paginate(3);
+        $post_user = $post->with(['category','tags','favorites'])->where('user_id', $user->id)->orderBy( 'updated_at', 'desc' )->paginate(9);
         
         return view('profile.user',compact('user','header'))->with([ 'posts'=>$post_user ]);
     }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -11,9 +11,10 @@ class TagController extends Controller
 {
     //タグ毎の投稿一覧取得
     public function index(Post $post,Category $category,Tag $tag){
-        $post_tag = $tag->posts()->orderBy( 'updated_at', 'desc' )->paginate(3);
+        $post_tag = $tag->getTagPaginate();
         $header = $post->inRandomOrder()->first();
-        return view('tags.index',compact('tag','header'))->with([
+        
+        return view('tags.index',compact('header'))->with([
             'posts' => $post_tag,
             'categories' => $category->get()
             ]);

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -16,8 +16,8 @@ class Category extends Model
     }
     
     public function getCategoryPaginate(){
-        return $this->posts()->with('category')->orderBy('updated_at','desc')->paginate(6);
-        //基本的な形は$this->posts()->paginate();
+        return $this->posts()->with('category')->orderBy('updated_at','desc')->paginate(9);
+        //基本的な形は$this->posts()->paginate();（1対多のリレーション）
         //with('category')はEagerロードと呼ばれ、データベースへのアクセスを1回で済ませてくれる手法
         /*
         リレーション先のデータを取り出すコードの書き方の手順は

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -13,14 +13,8 @@ class Tag extends Model
         return $this -> belongsToMany(Post::class);
     }
     
-    //投稿編集画面でのタグの初期値設定
-    public function tagCheck($selectedTags,$tag){
-        
-        foreach($selectedTags as $selectedTag){
-            if($selectedTag->id === $tag->id){
-                return true; 
-            }    
-        }    
-        
+    //タグごとの投稿取得
+    public function getTagPaginate(){
+        return $this->posts()->with('tags')->orderBy( 'updated_at','desc' )->paginate(9);
     }
 }

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -107,7 +107,7 @@
                   <div class="flex flex-col items-center text-center justify-center">
                     <h2 class="font-medium title-font text-gray-900 text-lg">Category</h2>
                     <div class="w-12 h-1 bg-indigo-500 rounded mt-2 mb-4"></div>
-                    <p class="text-base hover:underline">{{$post->category->name}}</p>
+                    <a href="/categories/{{$post->category->id}}"  class="text-base hover:underline">{{$post->category->name}}</a>
                   </div>
                   <div class="flex flex-col sm:mt-4 items-center text-center justify-center">
                     <h2 class="font-medium title-font text-gray-900 text-lg">Tag</h2>


### PR DESCRIPTION
## 変更の概要
* 変更の概要
eagerロードによるパフォーマンスの向上

* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
* 変更をする理由
N+1問題の解決
## やったこと、学んだこと
eagerロード（N+1問題）で起きていること。
→繰り返し処理のときに毎回クエリを実行しなくて済む。
クエリのログの確認の仕方も使ってみることができた。今までやっていなかったので、もう少し勉強必要。


## 課題、疑問
* 悩んでいること
* とくにレビューしてほしいところ
