### PR TITLE
fix:説明欄の文字数によるバリデーション、リダイレクト時の値の保持

### DIFF
--- a/app/Http/Requests/EditRequest.php
+++ b/app/Http/Requests/EditRequest.php
@@ -25,8 +25,21 @@ class EditRequest extends FormRequest
     {
         return [
             'post.title' => 'required|max:50',
+            'post.body' => 'max:200',
             
             //
         ];
     }
+    
+    public function messages()
+    {
+        return [
+            
+            'post.title.required' => 'タイトルは必ず入力してください。写真を更新する場合は再選択してください。',
+            'post.title.max' => 'タイトルは50文字以内で入力してください。写真を更新する場合は再選択してください。',
+            'post.body.max' => '写真説明は200文字以内で入力してください。写真を更新する場合は再選択してください。',
+            
+        ];
+    }
+    
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -26,16 +26,20 @@ class PostRequest extends FormRequest
         
         return [
             'post.title' => 'required|max:50',
+            'post.body' => 'max:200',
             'image' => 'required',
             
         ];
     }
-    
-    public function attributes()
+    public function messages()
     {
-    return [
-        'post.title' => '投稿タイトル',
-        'image' => '写真'
-    ];
+        return [
+            'image' => '写真を選択してください。',
+            'post.title.required' => 'タイトルは必ず入力してください。写真を再選択してください。',
+            'post.title.max' => 'タイトルは50文字以内で入力してください。写真を再選択してください。',
+            'post.body.max' => '写真説明は200文字以内で入力してください。写真を再選択してください。',
+            
+        ];
     }
+    
 }

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -19,7 +19,8 @@
         <style>
             .error{
                 color:red;
-                font-weight:bold
+                font-weight:bold;
+                font-size: 1em;
             }
         </style>
         
@@ -46,7 +47,7 @@
                                     <h2 class="underline underline-offset-4 decoration-orange-700 mb-2">投稿タイトル</h2>
                                     
                                     <input type="text" name="post[title]" value="{{ old('post.title') }}" class="w-full sm:w-5/6 mr-2 rounded-lg bg-gray-200 border-0">
-                                    <p class="error">{{$errors->first('post.title')}}</p>
+                                    <div class="error">{!!$errors->first('post.title')!!}</div>
                                     
                                     <!--
                                     nameで指定した入れ子の構造（post[title]）は
@@ -55,14 +56,14 @@
                                     
                                     <h2 class="underline underline-offset-4 decoration-orange-700 mb-2 mt-4">写真説明</h2>
                                     <textarea name="post[body]" class="h-36 w-full sm:w-5/6 mr-2 whitespace-pre-wrap rounded-lg bg-gray-200 border-0">{{ old('post.body') }}</textarea>
-                                    <p class="error">{{$errors->first('post.body')}}</p>
+                                    <div class="error">{!!$errors->first('post.body')!!}</div>
                                     <!--
                                     バリデーションのエラーメッセージのattributeはリクエストクラス（PostRequest）で指定できる
                                     -->
                                     <h2 class="underline underline-offset-4 decoration-orange-700 mb-2 mt-4">カテゴリー</h2>
                                     <select name="post[category_id]" class="rounded-lg border-0">
                                         @foreach($categories as $category)
-                                            <option value="{{$category->id}}">{{$category->name}}</option>
+                                            <option value="{{$category->id}}" {{ $category->id == old('post.category_id') ? "selected":"" }}>{{$category->name}}</option>
                                         @endforeach
                                     </select>
                                 </div>
@@ -72,7 +73,7 @@
                                         <img id="preview" src="" class="max-w-48 max-h-48 sm:max-w-72 sm:max-h-72 mb-2">
                                     </div>
                                     <input type="file" name="image" onchange="previewImage(this);">
-                                    <p class="error">{{$errors->first('image')}}</p>
+                                    <div class="error">{!!$errors->first('image')!!}</div>
                                     
                                 </div>
                             </div>
@@ -85,7 +86,7 @@
                                     </label>
                                     <select name="tag[]" class="js-example-basic-multiple", style="width: 100%" data-placeholder="Select a tag..." data-allow-clear="false" multiple="multiple" title="Select tag..." >
                                         @foreach($tags_spot as $tag)
-                                            <option value="{{$tag->id}}">{{$tag->name}}</option>
+                                            <option value="{{$tag->id}}" {{ in_array($tag->id, old('tag',[])) ? "selected":"" }}>{{$tag->name}}</option>
                                         @endforeach
                                     </select>
                                 </div>
@@ -95,7 +96,7 @@
                                     </label>
                                     <select name="tag[]" class="js-example-basic-multiple", style="width: 100%" data-placeholder="Select a tag..." data-allow-clear="false" multiple="multiple" title="Select tag..." >
                                         @foreach($tags_nature as $tag)
-                                            <option value="{{$tag->id}}">{{$tag->name}}</option>
+                                            <option value="{{$tag->id}}" {{ in_array($tag->id, old('tag',[])) ? "selected":"" }}>{{$tag->name}}</option>
                                         @endforeach
                                     </select>
                                 </div>
@@ -105,7 +106,7 @@
                                     </label>
                                     <select name="tag[]" class="js-example-basic-multiple", style="width: 100%" data-placeholder="Select a tag..." data-allow-clear="false" multiple="multiple" title="Select tag..." >
                                         @foreach($tags_animal as $tag)
-                                            <option value="{{$tag->id}}">{{$tag->name}}</option>
+                                            <option value="{{$tag->id}}" {{ in_array($tag->id, old('tag',[])) ? "selected":"" }}>{{$tag->name}}</option>
                                         @endforeach
                                     </select>
                                 </div>
@@ -123,8 +124,8 @@
                                 <div id="map" class="object-cover object-center h-full w-full"></div>
                             </div>
                             <div class="flex flex-col justify-start sm:flex sm:flex-row mt-2">
-                                <input id="lat" name="post[latitude]" type="hidden" class="rounded-lg bg-gray-100 border-0">
-                                <input id="lng" name="post[longitude]" type="hidden" class="rounded-lg bg-gray-100 border-0">
+                                <input id="lat" name="post[latitude]" type="hidden" class="rounded-lg bg-gray-100 border-0" value="{{ old('post.latitude') }}">
+                                <input id="lng" name="post[longitude]" type="hidden" class="rounded-lg bg-gray-100 border-0" value="{{ old('post.longitude') }}">
                             </div>
                             
                             <div class="flex justify-between">
@@ -147,11 +148,22 @@
 
         <script>
           function initAutocomplete() {
+            const defaultLatitude = {{ old('post.latitude') !== null ? old('post.latitude') : 35.6812362 }};
+            const defaultLongitude = {{ old('post.longitude') !== null ? old('post.longitude') : 139.7671248 }};
+            
             const map = new google.maps.Map(document.getElementById("map"), {
-              center: { lat: 35.6812362, lng: 139.7671248 },
+              center: { lat: defaultLatitude , lng: defaultLongitude },
               zoom: 13,
               mapTypeId: "roadmap",
             });
+            
+            // マーカーを初期位置に追加
+            const initialMarker = new google.maps.Marker({
+                map,
+                position: { lat: defaultLatitude, lng: defaultLongitude },
+                title: "initialPosition"
+            });
+            
             // Create the search box and link it to the UI element.
             const input = document.getElementById("pac-input");
             const searchBox = new google.maps.places.SearchBox(input);

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -43,18 +43,18 @@
                 <form action="/posts/{{$post->id}}/edit" method="POST" enctype="multipart/form-data">
                   @csrf
                   @method('PUT')
-                  <div class="flex flex-col sm:flex sm:flex-row">
-                    <section class="w-full sm:w-1/3">
+                  <div class="flex flex-col lg:flex lg:flex-row">
+                    <section class="w-full lg:w-1/3">
                       <h2 class="underline underline-offset-4 decoration-orange-700 mb-2">投稿タイトル</h2>
-                      <input type="text" name="post[title]" value="{{ old('post.title',$post->title) }}" class="w-full sm:w-5/6 mr-2 rounded-lg bg-gray-200 border-0">
+                      <input type="text" name="post[title]" value="{{ old('post.title',$post->title) }}" class="w-full lg:w-5/6 mr-2 rounded-lg bg-gray-200 border-0">
                       <p class="error">{{$errors->first('post.title')}}</p>
                         <!--
                         nameで指定した入れ子の構造（post[title]）は
                         それ以降は「.（ドット）」で繋いで取り出すことができる
                         -->
                       <h2 class="underline underline-offset-4 decoration-orange-700 mb-2 mt-4">写真説明</h2>
-                      <textarea name="post[body]" class="h-36 w-full sm:w-5/6 mr-2 whitespace-pre-wrap rounded-lg bg-gray-200 border-0">{{ old('post.body',$post->body) }}</textarea>
-                      
+                      <textarea name="post[body]" class="h-36 w-full lg:w-5/6 mr-2 whitespace-pre-wrap rounded-lg bg-gray-200 border-0">{{ old('post.body',$post->body) }}</textarea>
+                      <p class="error">{{$errors->first('post.body')}}</p>
                       
                       <h2 class="underline underline-offset-4 decoration-orange-700 mb-2 mt-4">カテゴリー</h2>
                       <select id="category" name="post[category_id]" class="rounded-lg border-0">
@@ -64,27 +64,28 @@
                       </select>
                     </section>
                     
-                    <section class="w-full mt-4 sm:mt-0 sm:w-2/3 flex flex-col items-center justify-center">
-                      <h2 class="sm:hidden underline underline-offset-4 decoration-orange-700 mb-2 mt-4">写真選択</h2>
-                      <div class="flex flex-col sm:flex sm:flex-row items-center space-x-8">
+                    <section class="w-full mt-4 lg:mt-0 lg:w-2/3 flex flex-col items-center justify-center">
+                      <h2 class="lg:hidden underline underline-offset-4 decoration-orange-700 mb-2 mt-4">写真選択</h2>
+                      <div class="flex flex-col lg:flex lg:flex-row items-center space-x-8">
                         <div>
-                          <h2 class="invisible sm:visible underline underline-offset-4 decoration-orange-700 mb-2">画像変更</h2>
+                          <h2 class="invisible lg:visible underline underline-offset-4 decoration-orange-700 mb-2">画像変更</h2>
                           <img src="{{ $post->image_path }}" class="max-w-48 max-h-48 sm:max-w-72 sm:max-h-72 mb-2">
                         </div>
                         
-                          <div class="invisible sm:visible ">
+                          <div class="invisible lg:visible ">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                               <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
                             </svg>
                           </div>
-                          <div class="sm:hidden mb-4">
+                          <div class="lg:hidden mb-4">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                               <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3" />
                             </svg>
                           </div>
                         <div class="flex flex-col justify-center items-center ">
-                          <img id="preview" src="" class="max-w-48 max-h-48 sm:max-w-72 sm:max-h-72 mb-2">
+                          <img id="preview" src="" class="max-w-48 max-h-48 lg:max-w-72 lg:max-h-72 mb-2">
                           <input type="file" name="image" onchange="previewImage(this);">
+                          <p class="error">{{$errors->first('image')}}</p>
                         </div>
                       </div>
                     </section>


### PR DESCRIPTION
## 変更の概要
* 変更の概要
文字数が多すぎるときのバリデーションエラーを設定
エラーによりリダイレクト時の値の保持

* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
* 変更をする理由
より投稿をしやすくするため。
エラーの処理

## やったこと、学んだこと
fileの内容はセキュリティの都合で保持できない（らしい）
その他の内容は基本的にoldに保存されている。これも検索結果の保持で使用したsessionの一つ。

## 課題、疑問
* 悩んでいること
* とくにレビューしてほしいところ
