### PR TITLE
fix:エラー時の画像保持

### DIFF
--- a/app/Http/Requests/EditRequest.php
+++ b/app/Http/Requests/EditRequest.php
@@ -24,8 +24,7 @@ class EditRequest extends FormRequest
     public function rules()
     {
         return [
-            'post.title' => 'required|max:50',
-            'post.body' => 'max:200',
+            
             
             //
         ];
@@ -35,9 +34,6 @@ class EditRequest extends FormRequest
     {
         return [
             
-            'post.title.required' => 'タイトルは必ず入力してください。写真を更新する場合は再選択してください。',
-            'post.title.max' => 'タイトルは50文字以内で入力してください。写真を更新する場合は再選択してください。',
-            'post.body.max' => '写真説明は200文字以内で入力してください。写真を更新する場合は再選択してください。',
             
         ];
     }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -25,19 +25,13 @@ class PostRequest extends FormRequest
     {
         
         return [
-            'post.title' => 'required|max:50',
-            'post.body' => 'max:200',
-            'image' => 'required',
+            
             
         ];
     }
     public function messages()
     {
         return [
-            'image' => '写真を選択してください。',
-            'post.title.required' => 'タイトルは必ず入力してください。写真を再選択してください。',
-            'post.title.max' => 'タイトルは50文字以内で入力してください。写真を再選択してください。',
-            'post.body.max' => '写真説明は200文字以内で入力してください。写真を再選択してください。',
             
         ];
     }

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -70,11 +70,18 @@
                                 <div class="w-full mt-4 sm:mt-0 sm:w-1/2 flex flex-col items-center justify-center">
                                     <h2 class="sm:hidden underline underline-offset-4 decoration-orange-700 mb-2 mt-4">写真選択</h2>
                                     <div>
-                                        <img id="preview" src="" class="max-w-48 max-h-48 sm:max-w-72 sm:max-h-72 mb-2">
+                                        <img id="preview" src="{{ session()->get('image') }}" class="max-w-48 max-h-48 sm:max-w-72 sm:max-h-72 mb-2">
                                     </div>
-                                    <input type="file" name="image" onchange="previewImage(this);">
-                                    <div class="error">{!!$errors->first('image')!!}</div>
-                                    
+                                    <button id="fileSelect" type="button" class="bg-gray-500 hover:bg-gray-400 text-white rounded px-4 py-2">画像を選択</button>
+                                    <input type="file" id="image" name="image" style="display:none" onchange="previewImage(this);">
+                                    <input type="hidden" name="post[image_path]" value="{{ session()->has('image') ? session()->get('image') :"" }}">
+                                    <div class="error" >{!!$errors->first('image')!!}</div>
+                                    <!--
+                                    previewにはセッションに保存されたパスがあればそれを表示。画像を再選択したらそちらの画像に更新される。
+                                    buttonと次のinputは画像選択ボタン。input type=fileのデフォルトのボタンだとエラーでリダイレクトしたときに
+                                    「画像が選択されていません」と出てしまうため、それを隠してボタンを新しく作っている。jsでinputもclick判定している。
+                                    →次のinputは、この時、ファイルは実際選択されていないが前に保存処理はしているので、それをrequestから保存するためのタグ。
+                                    -->
                                 </div>
                             </div>
                             
@@ -230,6 +237,16 @@
           }
           
           window.initAutocomplete = initAutocomplete;
+        </script>
+        <script>
+            const fileSelect = document.getElementById("fileSelect");
+            const image = document.getElementById("image");
+            
+            fileSelect.addEventListener("click", (e) => {
+              if (image) {
+                image.click();
+              }
+            }, false);
         </script>
         <script>
           function previewImage(obj)

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -66,10 +66,11 @@
                     
                     <section class="w-full mt-4 lg:mt-0 lg:w-2/3 flex flex-col items-center justify-center">
                       <h2 class="lg:hidden underline underline-offset-4 decoration-orange-700 mb-2 mt-4">写真選択</h2>
-                      <div class="flex flex-col lg:flex lg:flex-row items-center space-x-8">
+                      <h2 class="invisible lg:visible underline underline-offset-4 decoration-orange-700 mb-8 ">画像変更</h2>
+                      <div class="flex flex-col lg:flex lg:flex-row items-center justify-center space-x-8">
                         <div>
-                          <h2 class="invisible lg:visible underline underline-offset-4 decoration-orange-700 mb-2">画像変更</h2>
-                          <img src="{{ $post->image_path }}" class="max-w-48 max-h-48 sm:max-w-72 sm:max-h-72 mb-2">
+                          
+                          <img src="{{ session()->has('preImage') ? session()->get('preImage') :$post->image_path }}" class="max-w-48 max-h-48 sm:max-w-72 sm:max-h-72 mb-2">
                         </div>
                         
                           <div class="invisible lg:visible ">
@@ -83,9 +84,15 @@
                             </svg>
                           </div>
                         <div class="flex flex-col justify-center items-center ">
-                          <img id="preview" src="" class="max-w-48 max-h-48 lg:max-w-72 lg:max-h-72 mb-2">
-                          <input type="file" name="image" onchange="previewImage(this);">
+                          <img id="preview" src="{{ session()->get('newImage') }}" class="max-w-48 max-h-48 sm:max-w-72 sm:max-h-72 mb-2 ">
+                          <button id="fileSelect" type="button" class="bg-gray-500 hover:bg-gray-400 text-white rounded px-4 py-2">画像を選択</button>
+                          <input type="file" id="image" name="image" style="display:none" onchange="previewImage(this);">
+                          <input type="hidden" name="post[new_image_path]" value="{{ session()->has('newImage') ? session()->get('newImage') :"" }}">
                           <p class="error">{{$errors->first('image')}}</p>
+                          <!--
+                          基本的にcreateと同じだが、preImageとnewImageを使い分ける必要があったので、Controllerで処理を変えてる。
+                          あとは同じ。
+                          -->
                         </div>
                       </div>
                     </section>
@@ -238,6 +245,16 @@
           }
           
           window.initAutocomplete = initAutocomplete;
+        </script>
+        <script>
+            const fileSelect = document.getElementById("fileSelect");
+            const image = document.getElementById("image");
+            
+            fileSelect.addEventListener("click", (e) => {
+              if (image) {
+                image.click();
+              }
+            }, false);
         </script>
         <script>
           function previewImage(obj)


### PR DESCRIPTION
## 変更の概要
* 変更の概要
バリデーションエラーでリダイレクトした時に画像を保持するように変更

* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
* 変更をする理由
画像保持できることで再選択の必要がなくなる。

## やったこと、学んだこと
画像保存してからでないとうまく画像保持できなかった。
普通にoldではセキュリティの関係で保持できない。
→一度画像だけ保存処理してから、そのパスをセッションに保存して呼び出すことにした。
場合分けをしていくことで処理できたが、コントローラーが長くなってしまった。
モデルでの処理に一部移した方が良いかもしれない。

## 課題、疑問
* 悩んでいること
* とくにレビューしてほしいところ
